### PR TITLE
When recyclerView has no items, FastScroller shows handle #5

### DIFF
--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -413,6 +413,9 @@ public class FastScroller extends LinearLayout {
     }
 
     private void showScrollbar() {
+        if ((mRecyclerView.computeVerticalScrollRange() - mHeight) <= 0) {
+            return;
+        }
         float transX = getResources().getDimensionPixelSize(R.dimen.fastscroll_scrollbar_padding);
 
         mScrollbar.setTranslationX(transX);


### PR DESCRIPTION
This patch will hide scrollbar, when recyclerView does not have enough items to scroll.