### PR TITLE
Pass bubble and scroll views as params for onFastScrollStart listener method

### DIFF
--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScrollStateChangeListener.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScrollStateChangeListener.java
@@ -16,12 +16,14 @@
 
 package com.l4digital.fastscroll;
 
+import android.view.View;
+
 public interface FastScrollStateChangeListener {
 
     /**
      * Called when fast scrolling begins
      */
-    void onFastScrollStart();
+    void onFastScrollStart(View bubbleView, View scrollView);
 
     /**
      * Called when fast scrolling ends

--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -337,7 +337,7 @@ public class FastScroller extends LinearLayout {
             }
 
             if (mFastScrollStateChangeListener != null) {
-                mFastScrollStateChangeListener.onFastScrollStart();
+                mFastScrollStateChangeListener.onFastScrollStart(mBubbleView, mScrollbar);
             }
         case MotionEvent.ACTION_MOVE:
             final float y = event.getY();


### PR DESCRIPTION
Due to the issue #23 it is useful to have an access to the bubble view and the scroll view.
Links to those views are passed as params for `onFastScrollStart` listener method. So if another library draws something on the same parent layout we can call `.bringToFront()` on fast scroll views to avoid overlap.