### PR TITLE
Add padding to fastscroll bubble drawable

### DIFF
--- a/fastscroll/src/main/res/drawable/fastscroll_bubble.xml
+++ b/fastscroll/src/main/res/drawable/fastscroll_bubble.xml
@@ -32,4 +32,8 @@
         android:height="@dimen/fastscroll_bubble_size"
         android:width="@dimen/fastscroll_bubble_size" />
 
+    <padding
+        android:left="@dimen/fastscroll_bubble_padding"
+        android:right="@dimen/fastscroll_bubble_padding" />
+
 </shape>

--- a/fastscroll/src/main/res/values/dimens.xml
+++ b/fastscroll/src/main/res/values/dimens.xml
@@ -20,6 +20,7 @@
     <dimen name="fastscroll_bubble_radius">44dp</dimen>
     <dimen name="fastscroll_bubble_size">88dp</dimen>
     <dimen name="fastscroll_bubble_textsize">48sp</dimen>
+    <dimen name="fastscroll_bubble_padding">16dp</dimen>
 
     <dimen name="fastscroll_handle_height">40dp</dimen>
     <dimen name="fastscroll_handle_width">4dp</dimen>


### PR DESCRIPTION
If section text is more than one char, the sides of the bubble drawable are inline with the text (which doesn't look great). This fixes it.