### PR TITLE
Fix crash on null pointer 

### DIFF
--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -440,6 +440,10 @@ public class FastScroller extends LinearLayout {
     }
 
     private float getScrollProportion(RecyclerView recyclerView) {
+        if (recyclerView == null) {
+            return 0;
+        }
+
         final int verticalScrollOffset = recyclerView.computeVerticalScrollOffset();
         final int verticalScrollRange = recyclerView.computeVerticalScrollRange();
         final float rangeDiff = verticalScrollRange - mViewHeight;


### PR DESCRIPTION
Crash when recyclerView null in getScrollProportion

> Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.support.v7.widget.RecyclerView.computeVerticalScrollOffset()' on a null object reference
       at com.l4digital.fastscroll.FastScroller.getScrollProportion(FastScroller.java:443)
       at com.l4digital.fastscroll.FastScroller.access$200(FastScroller.java:51)
       at com.l4digital.fastscroll.FastScroller$3.run(FastScroller.java:221)
       at android.os.Handler.handleCallback(Handler.java:761)
       at android.os.Handler.dispatchMessage(Handler.java:98)
       at android.os.Looper.loop(Looper.java:156)
       at android.app.ActivityThread.main(ActivityThread.java:6523)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:942)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:832)