### PR TITLE
Consider using appcompat

### DIFF
--- a/example/src/main/res/layout/activity_example.xml
+++ b/example/src/main/res/layout/activity_example.xml
@@ -27,9 +27,6 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:bubbleColor="@color/fastscroll_bubble"
-        app:bubbleTextColor="@color/fastscroll_text"
-        app:handleColor="@color/fastscroll_handle"
         tools:listitem="@layout/item_example" />
-
+        
 </FrameLayout>

--- a/fastscroll/build.gradle
+++ b/fastscroll/build.gradle
@@ -38,6 +38,7 @@ android {
 }
 
 dependencies {
+    api 'androidx.appcompat:appcompat:1.0.2'
     api 'androidx.constraintlayout:constraintlayout:1.1.3'
     api 'androidx.recyclerview:recyclerview:1.0.0'
 }

--- a/fastscroll/lint.xml
+++ b/fastscroll/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<lint>
+    <issue id="RtlEnabled">
+        <ignore path="src/main/AndroidManifest.xml" />
+    </issue>
+</lint>

--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -726,7 +726,7 @@ public class FastScroller extends LinearLayout {
         @ColorInt int bubbleColor = accent;
         @ColorInt int handleColor = accent;
         @ColorInt int trackColor = Color.LTGRAY;
-        @ColorInt int textColor = Color.WHITE;
+        @ColorInt int textColor = getColorAttr(context, android.R.attr.textColorPrimary);
 
         boolean hideScrollbar = true;
         boolean showBubble = true;

--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -726,7 +726,7 @@ public class FastScroller extends LinearLayout {
         @ColorInt int bubbleColor = accent;
         @ColorInt int handleColor = accent;
         @ColorInt int trackColor = Color.LTGRAY;
-        @ColorInt int textColor = getColorAttr(context, android.R.attr.textColorPrimary);
+        @ColorInt int textColor = getColorAttr(context, android.R.attr.windowBackground);
 
         boolean hideScrollbar = true;
         boolean showBubble = true;

--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -723,11 +723,10 @@ public class FastScroller extends LinearLayout {
         bubbleSize = size;
 
         final int accent = getColorAttr(context, R.attr.colorAccent);
-        final int transparent = ContextCompat.getColor(context, android.R.color.transparent);
         @ColorInt int bubbleColor = accent;
         @ColorInt int handleColor = accent;
-        @ColorInt int trackColor = transparent;
-        @ColorInt int textColor = transparent;
+        @ColorInt int trackColor = Color.LTGRAY;
+        @ColorInt int textColor = Color.WHITE;
 
         boolean hideScrollbar = true;
         boolean showBubble = true;

--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -498,13 +498,7 @@ public class FastScroller extends LinearLayout {
         }
 
         DrawableCompat.setTint(bubbleImage, bubbleColor);
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            bubbleView.setBackground(bubbleImage);
-        } else {
-            //noinspection deprecation
-            bubbleView.setBackgroundDrawable(bubbleImage);
-        }
+        ViewCompat.setBackground(bubbleView, bubbleImage);
     }
 
     /**
@@ -728,10 +722,12 @@ public class FastScroller extends LinearLayout {
 
         bubbleSize = size;
 
-        @ColorInt int bubbleColor = Color.GRAY;
-        @ColorInt int handleColor = Color.DKGRAY;
-        @ColorInt int trackColor = Color.LTGRAY;
-        @ColorInt int textColor = Color.WHITE;
+        final int accent = getColorAttr(context, R.attr.colorAccent);
+        final int transparent = ContextCompat.getColor(context, android.R.color.transparent);
+        @ColorInt int bubbleColor = accent;
+        @ColorInt int handleColor = accent;
+        @ColorInt int trackColor = transparent;
+        @ColorInt int textColor = transparent;
 
         boolean hideScrollbar = true;
         boolean showBubble = true;
@@ -773,6 +769,13 @@ public class FastScroller extends LinearLayout {
 
         bubbleView.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize);
     }
+
+    private static int getColorAttr(Context context, int attrId) {
+        final TypedValue typedValue = new TypedValue();
+        context.getTheme().resolveAttribute(attrId, typedValue, true);
+        return typedValue.data;
+    }
+
 
     /**
      * A FastScrollListener can be added to a {@link FastScroller} to receive messages when a


### PR DESCRIPTION
There are 3 changes in this pull request:
1. Adding `appcompat` dependency, which I understand is expensive.
2. But the reward is you can detect an app's accent color, and use it as default color of fast scrolling components. I believe this is a common practice of [material library](https://github.com/material-components/material-components-android).
3. Lint rule to avoid warnings.