### PR TITLE
Fixed touch area

### DIFF
--- a/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
+++ b/fastscroll/src/main/java/com/l4digital/fastscroll/FastScroller.java
@@ -197,7 +197,7 @@ public class FastScroller extends LinearLayout {
     public boolean onTouchEvent(@NonNull MotionEvent event) {
         switch (event.getAction()) {
         case MotionEvent.ACTION_DOWN:
-            if (event.getX() < handleView.getX() - ViewCompat.getPaddingStart(handleView)) {
+            if (event.getX() < handleView.getX() - ViewCompat.getPaddingStart(scrollbar)) {
                 return false;
             }
 


### PR DESCRIPTION
Whenever a user clicked on the scrollbar area, the touch event was incorrectly dismissed if he clicked to the left of the handle because `paddingStart` of the `handleView` is always 0. The padding that we are actually interested in is applied to the parent `FrameLayout` (here defined as `scrollbar`).

The behavior can be easily observed when the start padding is set to a high value such as:
```
<resources>
	<dimen name="fastscroll_scrollbar_padding_start">48dp</dimen>
</resources>
```